### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,15 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #38bdf8;
+  --secondary: #60a5fa;
+}
+
+.dark {
+  --background: #1f2937;
+  --foreground: #f3f4f6;
+  --primary: #2563eb;
+  --secondary: #8b5cf6;
 }
 
 @theme inline {
@@ -10,13 +19,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeProvider from "../components/ThemeProvider";
+import ThemeToggle from "../components/ThemeToggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +26,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          {children}
+          <ThemeToggle />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,7 +20,7 @@ const Hero = () => {
     };
   }, []);
   const gradientStyle = {
-    background: "linear-gradient(-45deg, #4f46e5, #7c3aed)",
+    background: "linear-gradient(-45deg, var(--primary), var(--secondary))",
     backgroundSize: "400% 400%",
     animation: "gradient 10s ease infinite",
   };

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextValue {
+  theme: "light" | "dark";
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  // Initialize theme based on localStorage or system preference
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+    }
+  }, []);
+
+  // Apply theme class to html element and persist to localStorage
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { FaMoon, FaSun } from "react-icons/fa";
+import { useTheme } from "./ThemeProvider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle Dark Mode"
+      className="fixed bottom-4 right-4 z-50 bg-gray-200 dark:bg-gray-700 text-xl p-3 rounded-full shadow-lg transition-colors"
+    >
+      {theme === "dark" ? <FaMoon /> : <FaSun />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider and ThemeToggle components
- wire ThemeProvider into the layout
- customize global theme colors
- hook hero gradient to theme variables

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095e61fbc832abd036db66016c9a7