### PR TITLE
Add Tailwind config for dark-mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,15 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #38bdf8;
+  --secondary: #60a5fa;
+}
+
+.dark {
+  --background: #1f2937;
+  --foreground: #f3f4f6;
+  --primary: #2563eb;
+  --secondary: #8b5cf6;
 }
 
 @theme inline {
@@ -10,13 +19,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ThemeProvider from "../components/ThemeProvider";
+import ThemeToggle from "../components/ThemeToggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +26,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          {children}
+          <ThemeToggle />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -4,11 +4,11 @@ import profilePic from "../files/pf.jpg";
 
 const About = () => {
   return (
-    <section id="about" className="py-20 bg-gray-100 dark:bg-gray-800">
+    <section id="about" className="py-20 bg-white dark:bg-gray-800">
       <div className="container mx-auto px-6">
         <div className="flex flex-col md:flex-row items-center justify-between gap-40">
           <div className="md:w-1/2">
-            <div className="bg-gray-200 dark:bg-gray-700 rounded-full w-80 h-80 mx-auto overflow-hidden">
+            <div className="bg-white dark:bg-gray-700 rounded-full w-80 h-80 mx-auto overflow-hidden">
               <Image
                 src={profilePic}
                 alt="Tom Kluskens profile picture"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { FaGithub, FaLinkedin, FaEnvelope } from "react-icons/fa";
 
 const Footer = () => {
   return (
-    <footer className="py-4 bg-gray-900 text-white text-center">
+    <footer className="py-4 bg-white dark:bg-gray-900 text-gray-800 dark:text-white text-center">
       <div className="container mx-auto px-6">
         <p>© {new Date().getFullYear()} Tom Kluskens. All rights reserved.</p>
         <div className="flex justify-center space-x-6 mt-4">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,7 +20,7 @@ const Hero = () => {
     };
   }, []);
   const gradientStyle = {
-    background: "linear-gradient(-45deg, #4f46e5, #7c3aed)",
+    background: "linear-gradient(-45deg, var(--primary), var(--secondary))",
     backgroundSize: "400% 400%",
     animation: "gradient 10s ease infinite",
   };

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -86,7 +86,7 @@ const Skills = () => {
   return (
     <section
       id="skills"
-      className="py-20 bg-gray-100 dark:bg-gray-800"
+      className="py-20 bg-white dark:bg-gray-800"
       ref={sectionRef}
     >
       <div className="container mx-auto px-6">

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextValue {
+  theme: "light" | "dark";
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "light",
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  // Initialize theme based on localStorage or system preference
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+    }
+  }, []);
+
+  // Apply theme class to html element and persist to localStorage
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { FaMoon, FaSun } from "react-icons/fa";
+import { useTheme } from "./ThemeProvider";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle Dark Mode"
+      className={`fixed bottom-4 right-4 z-50 bg-white dark:bg-gray-700 text-xl p-3 rounded-full shadow-lg transition-colors transform transition-transform duration-300 ${theme === "dark" ? "rotate-180" : "rotate-0"}`}
+    >
+      {theme === "dark" ? <FaMoon /> : <FaSun />}
+    </button>
+  );
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,10 @@
+export default {
+  darkMode: 'class',
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode so `dark:` utilities respond to the ThemeProvider

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095e61fbc832abd036db66016c9a7